### PR TITLE
Do not put on top nodes on dragstart event.

### DIFF
--- a/chains.js
+++ b/chains.js
@@ -415,7 +415,6 @@ function chains()
     // allow nodes to be dragged to new positions
     node.call(d3.behavior.drag()
       .origin(function (d) { return d; })
-      .on("dragstart", function () { this.parentNode.appendChild(this); })
       .on("drag", dragmove));
   
     // add in the text for the nodes


### PR DESCRIPTION
This fixes the "double click event not firing" issue in WebKit browsers.
https://stackoverflow.com/questions/37921993/chrome-doesnt-fire-click-event-for-svg-element-firefox-does